### PR TITLE
fix(php): updating code style

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -233,8 +233,8 @@ function generateSetterPhp(indentSize, variableName) {
 
 	let code =
 		`
-${indentSize}public function set${variableNameUp}($${variableName}) {
-${indentSize}\tthis->${variableName} = $${variableName};
+\n${indentSize}public function set${variableNameUp}($${variableName}) {
+${indentSize}\t$this->${variableName} = $${variableName};
 ${indentSize}\treturn $this;
 ${indentSize}}
 `


### PR DESCRIPTION
This change adds in the missing `$` for the php setter. In addition it adds an extra blank line between the getter and setter for better code readability.