### PR TITLE
python language support enhance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,32 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [1.0.0]
 
 - Initial release
+
+## [1.4.1]
+
+- fixed some bugs
+
+- Now, this extension will use *Decorator* to encapsulation `python` fields. 
+
+  Just like this:
+
+  ```python
+  class r():
+      __name = ""
+      
+          @property
+      def name(self):
+          return self.__name
+      
+      @name.setter
+      def name(self, name):
+          self.__name = name
+  ```
+
+- It can discriminate indent now.
+
+- It can encapsulation many python fields at one time now.
+
+  GIF here:
+
+  ​	https://www.bilibili.com/read/cv17930525

--- a/extension.js
+++ b/extension.js
@@ -162,6 +162,22 @@ function generateGetterSetterAutomatically(text, returnableType, language){
 		if(text.startsWith('@') && language === 'java'){
 			continue;
 		}
+		if(text.startsWith('#') && language === 'python'){
+			continue;
+		}
+		if(text.startsWith('/') && language === 'cpp'){
+			continue;
+		}
+		if(text.startsWith('\.') && language === 'python'){
+			continue;
+		}
+		if(text.startsWith('\'') && language === 'python'){
+			continue;
+		}
+		if(text.startsWith('@') && language === 'python'){
+			continue;
+		}
+
 
 		let selectedText, indentSize, variableType, variableName;
 
@@ -180,6 +196,8 @@ function generateGetterSetterAutomatically(text, returnableType, language){
 				variableName = selectedText.split(' ')[1];
 			}
 		} else if (language === 'php'){
+			variableType = "";
+
 			let isConstructorVariable = selectedText.includes('$this->');
 	
 			if (isConstructorVariable) {
@@ -188,6 +206,7 @@ function generateGetterSetterAutomatically(text, returnableType, language){
 				variableName = selectedText.split('$')[1];
 			}
 		} else if (language === 'python'){
+			variableType = "";
 			let isConstructorVariable = selectedText.includes('self.');
 	
 			if (isConstructorVariable) {
@@ -199,6 +218,8 @@ function generateGetterSetterAutomatically(text, returnableType, language){
 			variableType = selectedText.split(' ')[0];
 			variableName = selectedText.split(' ')[1];	
 		} else if (language === 'javascript' || language === 'typescript'){
+
+			variableType = "";
 			let isConstructorVariable = selectedText.includes('.');
 	
 			if (isConstructorVariable) {
@@ -212,19 +233,61 @@ function generateGetterSetterAutomatically(text, returnableType, language){
 			vscode.window.showErrorMessage('Faulty Selection. Please make sure you select a variable.')
 			return; 
 		}
+		if(variableName.startsWith('@') && language === 'java'){
+			continue;
+		}
+		if(variableName.startsWith('#') && language === 'python'){
+			continue;
+		}
+		if(variableName.startsWith('/') && language === 'cpp'){
+			continue;
+		}
+		if(variableName.startsWith('\.') && language === 'python'){
+			continue;
+		}
+		if(variableName.startsWith('\'') && language === 'python'){
+			continue;
+		}
+		if(variableName.startsWith('@') && language === 'python'){
+			continue;
+		}
+
 
 		variableName.trim();
-		variableType.trim();
+		/**
+		 * 以下代码为修正
+		 */
+		if (language === 'java' ||  language === 'cpp' ) {
+			variableType.trim();
+		}
+		
 		
 		let code = '';
 		let langObject = lang[language];
-		let variableNameUp = variableName.charAt(0).toUpperCase() + variableName.slice(1);
+		let variableNameUp
+
+		if(language === "python")
+		{
+			// let variableName_ = variableName.replace("_","")
+			// variableNameUp = variableName_.charAt(0).toUpperCase() + variableName_.slice(1);
+			variableNameUp = variableName.replace(/__/g,"")
+		}
+		else{
+			variableNameUp = variableName.charAt(0).toUpperCase() + variableName.slice(1);
+		}
 
 		if (returnableType === "both") {
 			let getterPlain = langObject.getter
 			let setterPlain = langObject.setter				
-		
+			
+			/*
+			if(language === "python")
+			{
+				let getter = getterPlain.replace(/indentSize/g, indentSize).replace(/variableType/g, variableType).replace(/variableNameUp/g, variableNameUp).replace(/variableName/g, variableName);
+			}*/
+
 			let getter = getterPlain.replace(/indentSize/g, indentSize).replace(/variableType/g, variableType).replace(/variableNameUp/g, variableNameUp).replace(/variableName/g, variableName);
+			
 			let setter = setterPlain.replace(/indentSize/g, indentSize).replace(/variableType/g, variableType).replace(/variableNameUp/g, variableNameUp).replace(/variableName/g, variableName);
 
 			code = getter + setter;		

--- a/lang.js
+++ b/lang.js
@@ -1,3 +1,11 @@
+/*
+ * @Author: GJTY 1205995361@qq.com
+ * @Date: 2022-08-04 14:43:58
+ * @LastEditors: GJTY 1205995361@qq.com
+ * @LastEditTime: 2022-08-04 17:00:52
+ * @FilePath: \Dpc:\Users\12059\.vscode\extensions\gabsii.getter-setter-generator-1.4.0\lang.js
+ * @Description: 这是默认设置,请设置`customMade`, 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ */
 module.exports ={
 
     java: {
@@ -38,12 +46,12 @@ indentSize}
     },
     python: {
         getter: 
-`\nindentSizedef get_variableName(self):
-indentSize\treturn self.variableName
+`\n\nindentSize@property\nindentSizedef variableNameUp(self):
+indentSize    return self.variableName
 indentSize`,
         setter: 
-`\nindentSizedef set_variableName(self, variableName) :
-indentSize\tself.variableName = variableName
+`\nindentSize@variableNameUp.setter\nindentSizedef variableNameUp(self, variableNameUp):
+indentSize    self.variableName = variableNameUp
 `
     },
     cpp: {


### PR DESCRIPTION
- Now, this extension will use *Decorator* to encapsulation `python` fields. 

  Just like this:

  ```python
  class r():
      __name = ""
      
          @property
      def name(self):
          return self.__name
      
      @name.setter
      def name(self, name):
          self.__name = name
  ```

- It can discriminate indent now.

- It can encapsulation many python fields at one time now.

  GIF here:

  ​	https://www.bilibili.com/read/cv17930525


wrote this into CHANGELOG.md

 